### PR TITLE
ci: pin all action SHAs; fix notify-docs passing check

### DIFF
--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Respond
         if: steps.auth.outputs.allowed == 'true'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         env:
           KAPA_API_KEY: ${{ secrets.KAPA_API_KEY }}
           KAPA_PROJECT_ID: ${{ vars.KAPA_PROJECT_ID }}

--- a/.github/workflows/context7.yml
+++ b/.github/workflows/context7.yml
@@ -1,0 +1,17 @@
+name: Update Context7 Documentation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Context7 Documentation
+        id: context7
+        uses: rennf93/upsert-context7@1.1
+        with:
+          operation: refresh

--- a/.github/workflows/context7.yml
+++ b/.github/workflows/context7.yml
@@ -9,9 +9,9 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Update Context7 Documentation
         id: context7
-        uses: rennf93/upsert-context7@1.1
+        uses: rennf93/upsert-context7@c29ca04a37ecbab62635c0e94c3d8908049b9ed5 # 1.1
         with:
           operation: refresh

--- a/.github/workflows/engineer.yml
+++ b/.github/workflows/engineer.yml
@@ -32,7 +32,7 @@ jobs:
       statuses: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -41,27 +41,27 @@ jobs:
           git config user.name "examples-bot"
           git config user.email "noreply@deepgram.com"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: latest
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.22'
 
@@ -125,7 +125,7 @@ jobs:
 
       - name: Build, test, and open PR
         if: steps.auth.outputs.allowed != 'false' && steps.backpressure.outputs.blocked != 'true'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lead-fix.yml
+++ b/.github/workflows/lead-fix.yml
@@ -30,7 +30,7 @@ jobs:
       github.event.label.name == 'status:fix-needed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || '' }}
@@ -40,15 +40,15 @@ jobs:
           git config user.name "examples-bot"
           git config user.email "noreply@deepgram.com"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.22'
 
@@ -87,7 +87,7 @@ jobs:
 
       - name: Run instruction
         if: steps.attempts.outputs.max_reached != 'true'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lead-review.yml
+++ b/.github/workflows/lead-review.yml
@@ -33,19 +33,19 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'type:fix')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.22'
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Run instruction
         if: steps.auth.outputs.allowed != 'false'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,7 +1,7 @@
 name: Notify docs — new example ready
 
 # When a new example PR merges to main, create a [Suggestion] issue in deepgram-docs
-# so the content-pm workflow can queue a tutorial guide for it.
+# so the content-pm workflow can research and queue a tutorial guide for it.
 #
 # Required secrets:
 #   DOCS_PAT — PAT with issues:write scope on deepgram/deepgram-docs
@@ -18,14 +18,16 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.title, '[Example]')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: main
 
-      - name: Find merged example and create suggestion
+      - name: Create guide suggestion in deepgram-docs
         env:
           GH_TOKEN: ${{ secrets.DOCS_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -34,7 +36,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Find the example directory added by this PR
+          # Find the example directory added or modified by this PR
           EXAMPLE_DIR=$(git diff --name-only HEAD~1 HEAD \
             | grep '^examples/' \
             | head -1 \
@@ -48,16 +50,9 @@ jobs:
           SLUG=$(basename "$EXAMPLE_DIR")
           echo "Example slug: $SLUG"
 
-          # Read the example README for title and description
+          # Read the example README for title
           README_TITLE=$(head -3 "$EXAMPLE_DIR/README.md" 2>/dev/null \
             | grep '^#' | head -1 | sed 's/^# *//' || echo "$SLUG")
-
-          # Check it's marked passing in the README table
-          PASSING=$(grep -F "$SLUG" README.md | grep -c "✅ passing" || true)
-          if [ "$PASSING" -eq 0 ]; then
-            echo "Example not yet marked passing — skipping"
-            exit 0
-          fi
 
           # Create suggestion issue in deepgram-docs
           gh issue create \

--- a/.github/workflows/pm-dashboard.yml
+++ b/.github/workflows/pm-dashboard.yml
@@ -18,7 +18,7 @@ jobs:
       statuses: write
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -27,15 +27,15 @@ jobs:
           git config user.name "examples-bot"
           git config user.email "noreply@deepgram.com"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.22'
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run dashboard agent
         if: steps.existing.outputs.skip == 'false'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         env:
           KAPA_API_KEY: ${{ secrets.KAPA_API_KEY }}
           KAPA_PROJECT_ID: ${{ vars.KAPA_PROJECT_ID }}

--- a/.github/workflows/pm-suggestions.yml
+++ b/.github/workflows/pm-suggestions.yml
@@ -23,7 +23,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -119,7 +119,7 @@ jobs:
       # ── Pass: run PM agent ────────────────────────────────────────────
       - name: Route issue
         if: steps.permission.outputs.gate == 'pass'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -62,7 +62,7 @@ jobs:
       has_cli:         ${{ steps.scan.outputs.has_cli }}
       has_md:          ${{ steps.scan.outputs.has_md }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0
@@ -137,20 +137,20 @@ jobs:
     if: needs.detect.outputs.has_node == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - name: Install Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
       - name: Run Node.js tests
@@ -217,7 +217,7 @@ jobs:
 
       - name: Comment missing credentials
         if: steps.test.outputs.missing != '' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const missing = '${{ steps.test.outputs.missing }}'.trim().split(/\s+/).filter(Boolean);
@@ -233,11 +233,11 @@ jobs:
     if: needs.detect.outputs.has_python == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: Run Python tests
@@ -309,7 +309,7 @@ jobs:
 
       - name: Comment missing credentials
         if: steps.test.outputs.missing != '' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const missing = '${{ steps.test.outputs.missing }}'.trim().split(/\s+/).filter(Boolean);
@@ -325,11 +325,11 @@ jobs:
     if: needs.detect.outputs.has_go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.22'
       - name: Run Go tests
@@ -370,11 +370,11 @@ jobs:
     if: needs.detect.outputs.has_java == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -418,7 +418,7 @@ jobs:
     if: needs.detect.outputs.has_rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0
@@ -468,11 +468,11 @@ jobs:
     if: needs.detect.outputs.has_dotnet == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '8.0'
       - name: Run .NET tests
@@ -519,7 +519,7 @@ jobs:
     if: needs.detect.outputs.has_cli == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0
@@ -573,7 +573,7 @@ jobs:
     if: needs.detect.outputs.has_md == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || '' }}
           fetch-depth: 0

--- a/.github/workflows/test-existing.yml
+++ b/.github/workflows/test-existing.yml
@@ -30,8 +30,8 @@ jobs:
       has_failures: ${{ steps.test.outputs.has_failures }}
       failed_examples: ${{ steps.test.outputs.failed_examples }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -91,8 +91,8 @@ jobs:
       has_failures: ${{ steps.test.outputs.has_failures }}
       failed_examples: ${{ steps.test.outputs.failed_examples }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -164,8 +164,8 @@ jobs:
       has_failures: ${{ steps.test.outputs.has_failures }}
       failed_examples: ${{ steps.test.outputs.failed_examples }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.22'
 
@@ -223,8 +223,8 @@ jobs:
       has_failures: ${{ steps.test.outputs.has_failures }}
       failed_examples: ${{ steps.test.outputs.failed_examples }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -289,7 +289,7 @@ jobs:
       outdated_examples: ${{ steps.scan.outputs.outdated }}
       has_outdated: ${{ steps.scan.outputs.has_outdated }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Fetch latest SDK versions
         id: versions
@@ -373,7 +373,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -467,7 +467,7 @@ jobs:
 
       - name: Run fix agent for this failure
         if: steps.collect.outputs.has_target == 'true'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         env:
           KAPA_API_KEY: ${{ secrets.KAPA_API_KEY }}
           KAPA_PROJECT_ID: 1908afc6-c134-4c6f-a684-ed7d8ce91759

--- a/.github/workflows/vp.yml
+++ b/.github/workflows/vp.yml
@@ -26,7 +26,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
         run: echo "date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
       - name: Run VP instruction
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         env:
           KAPA_API_KEY: ${{ secrets.KAPA_API_KEY }}
           KAPA_PROJECT_ID: ${{ vars.KAPA_PROJECT_ID }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Action refs to commit SHAs across all 11 workflows (supply-chain security)
- Fix `notify-docs.yml`: remove broken passing check that looked for `✅ passing` markers in the README table (those markers don't exist — a merged `[Example]` PR is sufficient signal); also simplifies the issue body format

## Workflows changed

All workflows: floating `@v4`, `@v5`, `@beta` refs → pinned commit SHAs

`notify-docs.yml` specifically:
- Removed: `grep -F "$SLUG" README.md | grep -c "✅ passing"` gate (always returned 0, silently skipping every notification)
- Simplified issue body to match what `content-pm` in deepgram-docs expects